### PR TITLE
fix: match single or double quoted relation names

### DIFF
--- a/lua/dbt-nvim/jinja.lua
+++ b/lua/dbt-nvim/jinja.lua
@@ -1,20 +1,20 @@
 M = {}
 
 local function get_ref(line)
-    _, _, model_name = string.find(line, "{{%s*ref%(%s*'([%w_]+)'%s*%)%s*}}")
+    _, _, model_name = string.find(line, "{{%s*ref%(%s*[\'\"]([%w_]+)[\'\"]%s*%)%s*}}")
     return model_name
 end
 
 local function get_source(line)
     _, _, source_name, table_name = string.find(
                                         line,
-                                        "{{%s*source%(%s*'([%w_]+)'%s*,%s*'([%w_]+)'%s*%) }}"
+                                        "{{%s*source%(%s*[\'\"]([%w_]+)[\'\"]%s*,%s*[\'\"]([%w_]+)[\'\"]%s*%)%s*}}"
                                     )
     return source_name, table_name
 end
 
 local function get_schema(line)
-    _, _, model_name = string.find(line, "schema='([%w_]+)'")
+    _, _, model_name = string.find(line, "schema=[\'\"]([%w_]+)[\'\"]")
     return model_name
 end
 


### PR DESCRIPTION
This is a dope package!

Was having trouble getting the go-to commands to work in a dbt project until I realized that the match functions were looking for single-quotes.  Hope this is a change you'd be ok with!